### PR TITLE
feat(signals): hide all filters except custom and specific date (#8)

### DIFF
--- a/lib/features/user_signals/presentation/screens/user_signals_screen.dart
+++ b/lib/features/user_signals/presentation/screens/user_signals_screen.dart
@@ -374,34 +374,34 @@ class _FilterBottomSheetState extends State<_FilterBottomSheet> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  // Direction filter
-                  _buildSectionTitle('Direction'),
-                  const SizedBox(height: 12),
-                  Wrap(
-                    spacing: 8,
-                    children: [
-                      _buildChip('All', null, _selectedDirection),
-                      ..._directions.map((direction) =>
-                          _buildChip(direction, direction, _selectedDirection)),
-                    ],
-                  ),
-                  const SizedBox(height: 24),
+                  // Direction filter disabled for now
+                  // _buildSectionTitle('Direction'),
+                  // const SizedBox(height: 12),
+                  // Wrap(
+                  //   spacing: 8,
+                  //   children: [
+                  //     _buildChip('All', null, _selectedDirection),
+                  //     ..._directions.map((direction) =>
+                  //         _buildChip(direction, direction, _selectedDirection)),
+                  //   ],
+                  // ),
+                  // const SizedBox(height: 24),
 
-                  // Quick date filters
-                  _buildSectionTitle('Quick Date Filters'),
-                  const SizedBox(height: 12),
-                  Wrap(
-                    spacing: 8,
-                    runSpacing: 8,
-                    children: [
-                      _buildChip('All Time', null, _selectedDateFilter),
-                      ..._dateFilters.map((filter) => _buildChip(
-                          filter['label']!,
-                          filter['value']!,
-                          _selectedDateFilter)),
-                    ],
-                  ),
-                  const SizedBox(height: 24),
+                  // Quick date filters disabled for now
+                  // _buildSectionTitle('Quick Date Filters'),
+                  // const SizedBox(height: 12),
+                  // Wrap(
+                  //   spacing: 8,
+                  //   runSpacing: 8,
+                  //   children: [
+                  //     _buildChip('All Time', null, _selectedDateFilter),
+                  //     ..._dateFilters.map((filter) => _buildChip(
+                  //         filter['label']!,
+                  //         filter['value']!,
+                  //         _selectedDateFilter)),
+                  //   ],
+                  // ),
+                  // const SizedBox(height: 24),
 
                   // Custom date range
                   _buildSectionTitle('Custom Date Range'),


### PR DESCRIPTION
## 🔧 Changes Made

- Displayed only "Custom Date Range" and "Specific Date" filters in the Signals tab on the home screen.
- Commented out other filters for now — these will be re-enabled in a future release.

## 📌 Reason

- Closes #8
- Requested change to limit filter options in the current version.
- Simplifies user experience while backend and logic for other filters are being finalized.

## 📝 Notes

- Other filters are left in the codebase but commented for clarity.
- TODO added to restore them when ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Disabled the "Direction" and "Quick Date Filters" sections in the filter bottom sheet UI. These options are no longer visible or selectable, but other filter options remain available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->